### PR TITLE
Remove specific date in offline message

### DIFF
--- a/files/index.html
+++ b/files/index.html
@@ -71,7 +71,7 @@
                   <div class="col">
                      <img src="https://demo.pass.library.jhu.edu/img/error-icon.png" class="error-icon">
                      <p class="error-text"><br>PASS is currently offline.</p>
-                     <p class="helpful-text">We are currently performing scheduled maintenance. We will return on Tuesday afternoon (11/27). 
+                     <p class="helpful-text">We are currently performing scheduled maintenance.
                      If you have any urgent questions about PASS, please <a href="mailto:sayeed@jhu.edu" id="ember536" class="ember-view">contact us by email</a>.</p>
                   </div>
                </div>


### PR DESCRIPTION
The hardcoded date in the index.html file requires us to spin a new docker image each time we perform maintenance. I think this is a bad idea. 

All this does is remove the "We will return on..." sentence.