### PR TITLE
Implemented a simple dynamic string for a return date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
 FROM nginx:stable
 
+
+COPY bin/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY files/index.html /usr/share/nginx/html
 EXPOSE 80/tcp
+
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]

--- a/README.org
+++ b/README.org
@@ -4,3 +4,6 @@
 
 * Purpose
   This is a simple nginx container that hosts a single HTML file that displays that PASS is offline.
+
+* Dynamic string injection
+  If you pass RETURN_STRING to docker at runtime, it will inject this string after the initial "PASS is currently offline" statement. If not passed, there is nothing after this text

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cat /usr/share/nginx/html/index.html | envsubst > /tmp/index.html
+cp /tmp/index.html /usr/share/nginx/html/index.html
+cat /usr/share/nginx/html/index.html
+nginx -g "daemon off;"

--- a/files/index.html
+++ b/files/index.html
@@ -70,7 +70,7 @@
                <div class="row">
                   <div class="col">
                      <img src="https://demo.pass.library.jhu.edu/img/error-icon.png" class="error-icon">
-                     <p class="error-text"><br>PASS is currently offline.</p>
+                     <p class="error-text"><br>PASS is currently offline. ${RETURN_STRING}</p>
                      <p class="helpful-text">We are currently performing scheduled maintenance.
                      If you have any urgent questions about PASS, please <a href="mailto:sayeed@jhu.edu" id="ember536" class="ember-view">contact us by email</a>.</p>
                   </div>


### PR DESCRIPTION
My motive in this was to allow for the initial requirement to set a "We will return by..." type of string
in the offline text.

The implementation is simple, it uses the RETURN_STRING env var and passes the index.html file through envsubst. This allows
for us to, for example, use -e RETURN_STRING="We will return on Wednesday (June 12, 2019)." when running this image in Docker. If
the ENV Var is unset, it will substitute the variable with nothing, leaving a generic, dateless message.

I added an entrypoint.sh that runs the original text through envsubst and redirects it to a temp file, then copy the date file over to index.html.
Then we run nginx -g "daemon off;"